### PR TITLE
fixed redirect url on lose

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,7 +142,7 @@ async def handle_player_disconnect(player_id, websocket):
         save_score(players[player_id]["name"], players[player_id]["score"])
         del players[player_id]
         try:
-            await websocket.send_text(json.dumps({"action": "redirect", "url": "/index.html"}))
+            await websocket.send_text(json.dumps({"action": "redirect", "url": "https://coderlab.work/pong"}))
         except Exception as e:
             print(f"Error redirecting player: {e}")
         finally:


### PR DESCRIPTION
fixed redirect url for when a player loses rather than redirecting to coderlab.work/index.page it now goes to coderlab.work/pong. Also fixed nginx web server web socket route for /ws. Game is working and live @ https://coderlab.work/pong. 

Suggestion: Add immunity for players recently spawned into the game so they aren't able to be kicked off immediately after spawning if hit by a red ball. you can add a if statement when checking collisions to make sure a player has at least 3 or more scoring giving them 3 seconds to move before collisions with red balls have consequences.